### PR TITLE
Update scapy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jinja2==2.7.3
 xmlrunner==1.7.7
 requests==2.8.1
 netaddr==0.7.18
-scapy-python3==0.18
+scapy>=2.4.0
 pylint==1.8.2
 pyzmq==14.5.0
 distro

--- a/src/trex/Makefile
+++ b/src/trex/Makefile
@@ -29,8 +29,8 @@ all: force_pull
 force_pull: $(TAG_DONE_FLAG)
 	$(AT)cd $(WORK_DIR) && git pull $(TREX_URL) $(TREX_TAG)
 	@echo "git pull done"
-	$(AT)wget https://raw.githubusercontent.com/phaethon/scapy/v0.18/scapy/layers/all.py -O $(WORK_DIR)/scripts/external_libs/scapy-2.3.1/python3/scapy/layers/all.py
-	@echo "orignal SCAPY 2.3.1 layers/all.py was restored"
+	$(AT)wget https://raw.githubusercontent.com/secdev/scapy/v2.4.0/scapy/layers/all.py -O $(WORK_DIR)/scripts/external_libs/scapy-2.3.1/python3/scapy/layers/all.py
+	@echo "orignal SCAPY 2.4.0 layers/all.py was restored"
 
 $(WORK_DIR):
 	$(AT)git clone $(TREX_URL) $(WORK_DIR)


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3